### PR TITLE
Add AI SaaS boilerplate generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ next-env.d.ts
 
 # build artifacts
 public/r/themes
+boilerplate/

--- a/BOILERPLATE.md
+++ b/BOILERPLATE.md
@@ -1,0 +1,19 @@
+# AI SaaS Boilerplate
+
+This repository now includes a script to generate a trimmed boilerplate for building AI SaaS apps.
+The boilerplate includes:
+
+- Next.js + TypeScript setup
+- Authentication via better-auth with social providers
+- Usage based subscription helpers and billing checkout
+- Rate-limited AI example endpoint using Upstash and Google AI SDK
+- Basic UI shell with Tailwind and shadcn/ui
+
+## Usage
+
+```bash
+npm run create-boilerplate
+```
+
+A new `boilerplate` directory will be created containing the starter kit with theme-specific code removed.
+Use it as the foundation for your own AI SaaS application.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "generate-theme-registry": "tsx scripts/generate-theme-registry.ts && tsx scripts/generate-registry.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "create-boilerplate": "tsx scripts/create-boilerplate.ts"
   },
   "dependencies": {
     "@ai-sdk/google": "^1.2.14",

--- a/scripts/create-boilerplate.ts
+++ b/scripts/create-boilerplate.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// destination directory for the boilerplate
+const dest = path.resolve(process.cwd(), 'boilerplate');
+
+// clean previous output
+fs.rmSync(dest, { recursive: true, force: true });
+fs.mkdirSync(dest, { recursive: true });
+
+// copy tracked files using git archive to preserve ignore rules
+execSync(`git archive HEAD | tar -x -C ${dest}`);
+
+// remove files/directories that are specific to tweakcn and not needed for a generic AI SaaS starter
+const removePaths = [
+  'app/editor',
+  'app/figma',
+  'app/themes',
+  'app/r',
+  'app/not-found.tsx',
+  'app/apple-touch-icon.png',
+  'app/favicon-16x16.png',
+  'app/favicon-32x32.png',
+  'app/favicon.ico',
+  'assets',
+  'public/og-image.v050725.png',
+  'public/favicon-16x16.png',
+  'public/favicon-32x32.png',
+  'public/apple-touch-icon.png',
+  'scripts/generate-theme-registry.ts',
+  'scripts/generate-registry.ts'
+];
+
+for (const rel of removePaths) {
+  const p = path.join(dest, rel);
+  fs.rmSync(p, { recursive: true, force: true });
+}
+
+// write minimal README for the generated boilerplate
+const readme = `# AI SaaS Boilerplate\n\nThis folder was generated from the main project using \`scripts/create-boilerplate.ts\`.\nIt keeps authentication, billing, rate-limited AI endpoints and other reusable pieces while\ntrimming theme-editor specific code.\n`;
+fs.writeFileSync(path.join(dest, 'README.md'), readme);
+
+console.log(`Boilerplate generated at ${dest}`);


### PR DESCRIPTION
## Summary
- add script to generate a trimmed AI SaaS boilerplate from the current project
- document boilerplate usage and add npm script
- ignore generated boilerplate directory

## Testing
- `npm run create-boilerplate`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c3e14ade9c832392cb9c9a3dbe11d5