### PR TITLE
Fix theme default handling and layout structure

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { AuthDialogWrapper } from "@/components/auth-dialog-wrapper";
 import { Footer } from "@/components/footer";
 import { GetProDialogWrapper } from "@/components/get-pro-dialog-wrapper";
 import { Header } from "@/components/header";
+import { ThemeScript } from "@/components/theme-script";
 import { PostHogInit } from "@/components/posthog-init";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
@@ -44,8 +45,9 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" suppressHydrationWarning>
+      <body className="bg-background font-sans antialiased">
+        <ThemeScript />
         <NuqsAdapter>
           <Suspense>
             <QueryProvider>
@@ -53,9 +55,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <TooltipProvider>
                   <AuthDialogWrapper />
                   <GetProDialogWrapper />
-                  <Header />
-                  <main className="flex min-h-svh flex-col">{children}</main>
-                  <Footer />
+                  <div className="flex min-h-svh flex-col">
+                    <Header />
+                    <main className="flex-1">{children}</main>
+                    <Footer />
+                  </div>
                   <Toaster />
                 </TooltipProvider>
               </ThemeProvider>

--- a/app/pricing/layout.tsx
+++ b/app/pricing/layout.tsx
@@ -1,12 +1,5 @@
-import { Footer } from "@/components/footer";
-import { Header } from "@/components/header";
-
 export default function PricingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main className="flex flex-grow flex-col">{children}</main>
-      <Footer />
-    </div>
+    <div className="flex flex-1 flex-col">{children}</div>
   );
 }

--- a/components/theme-script.tsx
+++ b/components/theme-script.tsx
@@ -1,0 +1,44 @@
+import { THEME_STORAGE_KEY } from "@/components/theme-provider";
+
+const THEME_INITIALIZER = `(() => {
+  const storageKey = "${THEME_STORAGE_KEY}";
+  const preferDarkQuery = "(prefers-color-scheme: dark)";
+  const root = document.documentElement;
+
+  const apply = (theme) => {
+    if (theme !== "light" && theme !== "dark") {
+      return;
+    }
+
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+    root.style.colorScheme = theme;
+  };
+
+  try {
+    const storedTheme = localStorage.getItem(storageKey);
+
+    if (storedTheme === "light" || storedTheme === "dark") {
+      apply(storedTheme);
+      return;
+    }
+  } catch {
+    // Ignore storage errors (e.g., restricted access)
+  }
+
+  let prefersDark = false;
+
+  try {
+    prefersDark = typeof window.matchMedia === "function"
+      ? window.matchMedia(preferDarkQuery).matches
+      : false;
+  } catch {
+    prefersDark = false;
+  }
+
+  apply(prefersDark ? "dark" : "light");
+})();`;
+
+export function ThemeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: THEME_INITIALIZER }} />;
+}

--- a/components/theme-script.tsx
+++ b/components/theme-script.tsx
@@ -29,11 +29,17 @@ const THEME_INITIALIZER = `(() => {
   let prefersDark = false;
 
   try {
-    prefersDark = typeof window.matchMedia === "function"
-      ? window.matchMedia(preferDarkQuery).matches
-      : false;
+    if (typeof window.matchMedia === "function") {
+      prefersDark = window.matchMedia(preferDarkQuery).matches;
+    } else {
+      // Fallback to the app's default theme when matchMedia is unavailable
+      apply("dark");
+      return;
+    }
   } catch {
-    prefersDark = false;
+    // If querying matchMedia fails, fallback to the app's default theme
+    apply("dark");
+    return;
   }
 
   apply(prefersDark ? "dark" : "light");


### PR DESCRIPTION
## Summary
- respect the user's stored theme preference and fall back to the system color scheme when possible
- wrap the main layout content in a flex column so the footer sits at the bottom and set baseline body classes to match the theme
- run a hydration-safe theme initialization script before render and harden storage access so the chosen palette is applied without a flash
- remove the redundant header/footer wrapper from the pricing layout so it uses the global chrome only once

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c8d3bb32648323a4f9964d43d59108